### PR TITLE
Fix: Use configured port in TUI ServerScreen instead of hardcoded default

### DIFF
--- a/apps/tui/src/components/ServerScreen.tsx
+++ b/apps/tui/src/components/ServerScreen.tsx
@@ -1,4 +1,5 @@
 import { NETWORK } from "@ccflare/core";
+import { Config } from "@ccflare/config";
 import { Box, Text, useInput } from "ink";
 
 interface ServerScreenProps {
@@ -7,7 +8,9 @@ interface ServerScreenProps {
 
 export function ServerScreen({ onBack }: ServerScreenProps) {
 	// Server is auto-started now, so just show the running status
-	const port = NETWORK.DEFAULT_PORT;
+	// Use the same logic as main.ts line 208
+	const config = new Config();
+	const port = config.getRuntime().port || NETWORK.DEFAULT_PORT;
 	const url = `http://localhost:${port}`;
 
 	useInput((input, key) => {


### PR DESCRIPTION
Fixes an issue where the TUI ServerScreen component displayed port 8080 even when the server was configured to run on a different port.

**Problem:**
- ServerScreen was hardcoded to use `NETWORK.DEFAULT_PORT` (8080)
- Server actually runs on configured port (e.g., 8090)
- This caused confusion as TUI showed wrong port

**Solution:**
- ServerScreen now reads port from `config.getRuntime().port` like main.ts does
- Uses same logic: `config.getRuntime().port || NETWORK.DEFAULT_PORT`

**Testing:**
- Verified ServerScreen now shows correct configured port
- Dashboard opens at correct URL when pressing 'd'